### PR TITLE
[fix] Some name fields are optional for ORCID profiles

### DIFF
--- a/src/Profile.php
+++ b/src/Profile.php
@@ -106,6 +106,9 @@ class Profile
         $this->raw();
         $details = $this->person()->name;
 
-        return $details->{'given-names'}->value . ' ' . $details->{'family-name'}->value;
+        // "given-names" is a required field on ORCID profiles.
+        // "family-name", however, may or may not be available.
+        // https://members.orcid.org/api/tutorial/reading-xml#names
+        return $details->{'given-names'}->value . ($details->{'family-name'} ? ' ' . $details->{'family-name'}->value : '');
     }
 }


### PR DESCRIPTION
While "given-names" is always required for a profile, "family-name" may
or may not be available. So, we check if it's there before trying to
grab a value from it.

Refs: https://members.orcid.org/api/tutorial/reading-xml#names
Fixes: https://help.hubzero.org/support/ticket/11529